### PR TITLE
Develop

### DIFF
--- a/django/a_core/settings/product.py
+++ b/django/a_core/settings/product.py
@@ -3,25 +3,25 @@ from .base import *
 DEBUG = False
 
 ALLOWED_HOSTS = [
-    "myapp.com",
-    "www.myapp.com",
-    "api.myapp.com",
+    "dangma.store",
+    "www.dangma.store",
+    "api.dangma.store",
     "localhost",
     "127.0.0.1",
-    "52.78.37.115",  # EC2 IP
+    "13.125.219.86",  # EC2 IP
 ]
 CORS_ALLOWED_ORIGINS = [
-    "https://myapp.com",  # 프론트 배포 도메인
-    "https://www.myapp.com",  # 프론트 배포 도메인
-    "https://api.myapp.com",  # 백엔드 배포 도메인
+    "https://dangma.store",
+    "https://www.dangma.store",
+    "https://api.dangma.store",
     "http://localhost:5173",
     "http://localhost:3000",
     "http://localhost:8000",
 ]
 CSRF_TRUSTED_ORIGINS = [
-    "https://myapp.com",
-    "https://www.myapp.com",
-    "https://api.myapp.com",
+    "https://dangma.store",
+    "https://www.dangma.store",
+    "https://api.dangma.store",
     "http://localhost:5173",  # Vite dev server
     "http://localhost:3000",  # React / Next.js dev server
     "http://localhost:8000",  # Django dev server

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -65,13 +65,13 @@ http {
         }
 
         location /static/ {
-            proxy_pass https://${AWS_CLOUDFRONT_DOMAIN}/static/;
-            proxy_set_header Host ${AWS_CLOUDFRONT_DOMAIN};
+            proxy_pass https://d25ace22rk27wr.cloudfront.net/static/;
+            proxy_set_header Host d25ace22rk27wr.cloudfront.net;
         }
 
         location /media/ {
-            proxy_pass https://${AWS_CLOUDFRONT_DOMAIN}/media/;
-            proxy_set_header Host ${AWS_CLOUDFRONT_DOMAIN};
+            proxy_pass https://d25ace22rk27wr.cloudfront.net/media/;
+            proxy_set_header Host d25ace22rk27wr.cloudfront.net;
         }
 
         error_page 500 502 503 504 /50x.html;


### PR DESCRIPTION
### 수정목록
1. **Django Settings 변경** (`django/a_core/settings/product.py`):
   - `ALLOWED_HOSTS` 값 변경:
     - 기존: `"myapp.com"`, `"www.myapp.com"`, `"api.myapp.com"`, `"52.78.37.115"`
     - 변경: `"dangma.store"`, `"www.dangma.store"`, `"api.dangma.store"`, `"13.125.219.86"`
   - `CORS_ALLOWED_ORIGINS` 값 변경:
     - 기존: `"https://myapp.com"`, `"https://www.myapp.com"`, `"https://api.myapp.com"`
     - 변경: `"https://dangma.store"`, `"https://www.dangma.store"`, `"https://api.dangma.store"`
   - `CSRF_TRUSTED_ORIGINS` 값 변경:
     - 기존: `"https://myapp.com"`, `"https://www.myapp.com"`, `"https://api.myapp.com"`
     - 변경: `"https://dangma.store"`, `"https://www.dangma.store"`, `"https://api.dangma.store"`

2. **Nginx 설정 변경** (`nginx/nginx.conf`):
   - `/static/` 및 `/media/` 경로의 `proxy_pass` 및 `proxy_set_header` 값 변경:
     - 기존: `${AWS_CLOUDFRONT_DOMAIN}`
     - 변경: `d25ace22rk27wr.cloudfront.net`

---

### 수정내용
- **도메인 및 IP 주소 변경**:
  - 기존 도메인 `myapp.com` → 새로운 도메인 `dangma.store`로 변경.
  - AWS EC2 IP 주소를 `52.78.37.115`에서 `13.125.219.86`으로 갱신.
- **CloudFront 도메인 하드코딩**:
  - `${AWS_CLOUDFRONT_DOMAIN}` 변수 사용 대신 `d25ace22rk27wr.cloudfront.net`로 설정.

---

### 특이사항
1. **환경설정 하드코딩**:
   - Nginx 설정에서 CloudFront 도메인을 변수에서 직접 하드코딩(`d25ace22rk27wr.cloudfront.net`)으로 변경.
   - AWS 환경에서 도메인이 변경되면 수정이 필요할 수 있으므로 유지보수에 유의해야 합니다.
2. **배포 환경 반영 필요**:
   - Django 설정에서 `ALLOWED_HOSTS`, `CORS_ALLOWED_ORIGINS`, `CSRF_TRUSTED_ORIGINS`의 변경된 도메인이 실제 배포 환경에서 정상적으로 동작하는지 확인이 필요합니다.
3. **보안**:
   - 변경된 IP 및 도메인 설정이 안전한지 검토 및 테스트가 요구됩니다.
