### PR TITLE
41 feat profile

### DIFF
--- a/django/a_apis/api/users.py
+++ b/django/a_apis/api/users.py
@@ -1,11 +1,10 @@
 from a_apis.auth.bearer import AuthBearer
 from a_apis.models import EmailVerification
 from a_apis.schema.users import *
-
-# from a_apis.service.common_parser import CommonParser
 from a_apis.service.email import EmailService
 from a_apis.service.users import UserService
 from ninja import Router
+from ninja.files import UploadedFile
 
 router = Router(auth=AuthBearer())
 public_router = Router()
@@ -140,14 +139,118 @@ def logout(request, data: LogoutSchema):
 
 
 @router.put("/update-profile", response=ErrorResponseSchema)
-def update_profile(request, data: UpdateProfileSchema):
+def update_profile(
+    request, data: UpdateProfileSchema, profile_image: UploadedFile = None
+):
     """
     회원정보 수정 API
 
     인증 필수: Bearer 토큰 헤더 필요
-    필수 항목: 변경할 항목(name, phone 등)
+
+    변경 가능 항목:
+    - nickname: 닉네임 변경 (선택사항)
+    - phone_number: 휴대폰 번호 변경 (선택사항)
+    - profile_image: 프로필 이미지 변경 (파일 업로드, 선택사항)
+    - remove_profile_image: 프로필 이미지 삭제 여부 (Boolean, 선택사항, 기본값: false)
+
+    프로필 이미지 처리:
+    1. profile_image 전송: 새 이미지로 교체
+    2. remove_profile_image=true: 프로필 이미지 삭제
+    3. 둘 다 전송하지 않음: 기존 이미지 유지
+
+    두 옵션이 함께 전송된 경우 remove_profile_image가 우선 적용됩니다.
 
     성공: 정보 수정 완료 메시지
     실패: 유효성 검증 오류 메시지
     """
-    return UserService.update_user_profile(request, data)
+    return UserService.update_user_profile(request, data, profile_image)
+
+
+@router.put("/change-password", response=ErrorResponseSchema)
+def change_password(request, data: PasswordChangeSchema):
+    """
+    비밀번호 변경 API
+
+    인증 필수: Bearer 토큰 헤더 필요
+
+    필수 항목:
+    - current_password: 현재 비밀번호
+    - new_password: 새 비밀번호
+
+    성공: 비밀번호 변경 완료 메시지
+    실패: 현재 비밀번호 불일치 또는 기타 오류 메시지
+    """
+    return UserService.change_user_password(request, data)
+
+
+@router.get(
+    "/reviews", response={200: ReceivedReviewsResponseSchema, 400: ErrorResponseSchema}
+)
+def get_received_reviews(
+    request, user_id: Optional[int] = None, page: int = 1, page_size: int = 10
+):
+    """
+    거래 후기 조회 API
+
+    - user_id가 제공되면 해당 사용자의 거래 후기를 조회
+    - user_id가 없으면 현재 로그인한 사용자의 거래 후기를 조회
+
+    쿼리 파라미터:
+    - user_id: 조회할 사용자 ID (선택사항, 없으면 현재 사용자)
+    - page: 페이지 번호 (기본값: 1)
+    - page_size: 페이지 크기 (기본값: 10)
+
+    성공: 거래 후기 목록 반환
+    실패: 오류 메시지
+    """
+    if user_id is None:
+        # 내 후기 조회
+        result = UserService.get_received_reviews(
+            request=request, page=page, page_size=page_size
+        )
+    else:
+        # 특정 사용자 후기 조회
+        result = UserService.get_received_reviews(
+            user_id=user_id, page=page, page_size=page_size
+        )
+
+    if not result["success"]:
+        return 400, result
+    return 200, result
+
+
+@router.get(
+    "/manner-ratings",
+    response={200: ReceivedMannerRatingsResponseSchema, 400: ErrorResponseSchema},
+)
+def get_received_manner_ratings(
+    request, user_id: Optional[int] = None, page: int = 1, page_size: int = 10
+):
+    """
+    매너 평가 조회 API
+
+    - user_id가 제공되면 해당 사용자의 매너 평가를 조회
+    - user_id가 없으면 현재 로그인한 사용자의 매너 평가를 조회
+
+    쿼리 파라미터:
+    - user_id: 조회할 사용자 ID (선택사항, 없으면 현재 사용자)
+    - page: 페이지 번호 (기본값: 1)
+    - page_size: 페이지 크기 (기본값: 10)
+
+    성공: 매너 평가 목록 반환
+    실패: 오류 메시지
+    """
+    if user_id is None:
+        # 내 매너 평가 조회
+        result = UserService.get_received_manner_ratings(
+            request=request, page=page, page_size=page_size
+        )
+    else:
+        # 특정 사용자 매너 평가 조회
+        result = UserService.get_received_manner_ratings(
+            user_id=user_id, page=page, page_size=page_size
+        )
+
+    if not result["success"]:
+        return 400, result
+    return 200, result

--- a/django/a_apis/schema/users.py
+++ b/django/a_apis/schema/users.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ninja import Field, Schema
 from pydantic import EmailStr, field_validator, model_validator
@@ -104,5 +104,75 @@ class LogoutSchema(Schema):
 
 class UpdateProfileSchema(Schema):
     nickname: Optional[str] = Field(None, description="변경할 닉네임")
-    password: Optional[str] = Field(None, description="변경할 비밀번호")
     phone_number: Optional[str] = Field(None, description="변경할 휴대폰 번호")
+    remove_profile_image: Optional[bool] = Field(
+        False, description="프로필 이미지 삭제 여부"
+    )
+
+
+class PasswordChangeSchema(Schema):
+    """비밀번호 변경 스키마"""
+
+    current_password: str = Field(..., description="현재 비밀번호")
+    new_password: str = Field(..., description="새 비밀번호")
+
+
+# 거래 후기 관련 스키마 추가
+class ReviewerSchema(Schema):
+    """후기 작성자 정보 스키마"""
+
+    id: int = Field(..., description="작성자 ID")
+    nickname: str = Field(..., description="닉네임")
+    profile_img_url: Optional[str] = Field(None, description="프로필 이미지 URL")
+    location: Optional[str] = Field(None, description="인증한 동네")
+
+
+class ReceivedReviewSchema(Schema):
+    """받은 거래 후기 스키마"""
+
+    id: int = Field(..., description="후기 ID")
+    product_id: int = Field(..., description="상품 ID")
+    product_title: str = Field(..., description="상품 제목")
+    content: str = Field(..., description="후기 내용")
+    created_at: str = Field(..., description="작성 일시")
+    reviewer: ReviewerSchema = Field(..., description="작성자 정보")
+
+
+class ReceivedReviewsResponseSchema(Schema):
+    """받은 거래 후기 응답 스키마"""
+
+    success: bool = Field(..., description="요청 성공 여부")
+    message: str = Field(..., description="응답 메시지")
+    data: Optional[List[ReceivedReviewSchema]] = Field(
+        None, description="받은 후기 목록"
+    )
+    total_count: Optional[int] = Field(None, description="총 후기 수")
+    page: Optional[int] = Field(None, description="현재 페이지")
+    page_size: Optional[int] = Field(None, description="페이지 크기")
+    total_pages: Optional[int] = Field(None, description="총 페이지 수")
+
+
+class ReceivedMannerRatingSchema(Schema):
+    """받은 매너 평가 스키마"""
+
+    id: int = Field(..., description="평가 ID")
+    product_id: int = Field(..., description="상품 ID")
+    product_title: str = Field(..., description="상품 제목")
+    rating_type: str = Field(..., description="평가 유형")
+    rating_display: str = Field(..., description="평가 표시명")
+    created_at: str = Field(..., description="작성 일시")
+    rater: ReviewerSchema = Field(..., description="평가자 정보")
+
+
+class ReceivedMannerRatingsResponseSchema(Schema):
+    """받은 매너 평가 응답 스키마"""
+
+    success: bool = Field(..., description="요청 성공 여부")
+    message: str = Field(..., description="응답 메시지")
+    data: Optional[List[ReceivedMannerRatingSchema]] = Field(
+        None, description="받은 매너 평가 목록"
+    )
+    total_count: Optional[int] = Field(None, description="총 매너 평가 수")
+    page: Optional[int] = Field(None, description="현재 페이지")
+    page_size: Optional[int] = Field(None, description="페이지 크기")
+    total_pages: Optional[int] = Field(None, description="총 페이지 수")


### PR DESCRIPTION
### 수정 목록
#### 1. **`users.py` (API)**
- **`PUT /update-profile`**: 
  - 프로필 이미지 업로드 및 삭제 기능 추가 (`profile_image` 파일, `remove_profile_image` boolean).
  - 지원하는 수정 항목 추가 (`nickname`, `phone_number`, `profile_image`, `remove_profile_image`).
  - 로직 수정: `remove_profile_image`가 우선 적용되도록 처리.
- **`PUT /change-password`**: 
  - 비밀번호 변경 API 추가.
- **`GET /reviews`**: 
  - 거래 후기 조회 API 추가.
  - `user_id`로 특정 사용자 후기를 조회하거나, 로그인한 사용자의 후기를 조회 가능.
- **`GET /manner-ratings`**: 
  - 매너 평가 조회 API 추가.
  - `user_id`로 특정 사용자 매너 평가를 조회하거나, 로그인한 사용자의 매너 평가 조회 가능.

#### 2. **`users.py` (Schema)**
- `UpdateProfileSchema`: 
  - `remove_profile_image` 필드 추가.
- `PasswordChangeSchema`: 
  - 비밀번호 변경을 위한 `current_password`, `new_password` 필드 추가.
- 신규 스키마:
  - `ReviewerSchema`: 작성자 정보 스키마.
  - `ReceivedReviewSchema`: 받은 거래 후기 스키마.
  - `ReceivedReviewsResponseSchema`: 거래 후기 응답 스키마.
  - `ReceivedMannerRatingSchema`: 받은 매너 평가 스키마.
  - `ReceivedMannerRatingsResponseSchema`: 매너 평가 응답 스키마.

#### 3. **`users.py` (Service)**
- **`update_user_profile`**: 
  - 닉네임, 전화번호, 프로필 이미지 업로드/삭제 로직 추가.
- **`change_user_password`**: 
  - 현재 비밀번호 확인 후 새 비밀번호 설정 로직 추가.
- **`get_received_reviews`**: 
  - 거래 후기 조회 추가 (페이지네이션 포함).
- **`get_received_manner_ratings`**: 
  - 매너 평가 조회 추가 (페이지네이션 포함).

#### 4. **`test_users.py` (Tests)**
- 신규 테스트 추가:
  - 닉네임 변경 테스트.
  - 프로필 이미지 업로드/삭제 테스트.
  - 프로필 이미지 업로드와 삭제 동시 요청 시 삭제 우선 처리 테스트.

---

### 수정 내용
- **API 추가**: 회원정보 수정, 비밀번호 변경, 후기 조회, 매너 평가 조회.
- **로직 개선**: 프로필 이미지 처리 로직 추가 및 우선순위 적용.
- **테스트 강화**: 다양한 상황에 대한 테스트 케이스 추가.

---

### 특이사항
1. **프로필 이미지 처리**:
   - 삭제(`remove_profile_image`)와 업로드(`profile_image`)가 동시에 요청되면 삭제가 우선 적용.
2. **거래 후기에 인증 지역 정보 추가**:
   - 작성자의 인증된 지역을 포함하여 응답.
3. **테스트 강화**:
   - Mock 객체 및 임시 이미지 파일을 활용하여 업로드/삭제 관련 테스트 수행.
4. **페이지네이션**:
   - 거래 후기 및 매너 평가 API에서 페이지네이션 처리 구현.