### PR TITLE
security: 호스트 헤더 검증, 레이트 리미팅 및 봇 차단 설정으로 Nginx 보안 강화

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,13 +13,47 @@ http {
     keepalive_timeout 65;
     types_hash_max_size 2048;
     types_hash_bucket_size 64;
+    
+    # 유효한 호스트 이름 검증 (정확한 도메인만 허용)
+    map $http_host $is_valid_host {
+        default 0;
+        "dangma.store" 1;
+        "www.dangma.store" 1;
+        "api.dangma.store" 1;
+        "localhost" 1;
+        "localhost:8000" 1;
+        "127.0.0.1" 1;
+        "127.0.0.1:8000" 1;
+    }
+    
+    # 보안 헤더 설정
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options SAMEORIGIN;
+    add_header X-XSS-Protection "1; mode=block";
+    
+    # 과도한 요청 제한 설정 (Rate Limiting)
+    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=admin_limit:10m rate=5r/s;
+    
+    # 봇 스캐닝 탐지 및 제한
+    map $http_user_agent $bad_bot {
+        default 0;
+        ~*(scanner|nmap|nikto|sqlmap|dirbuster|gobuster|zgrab|masscan) 1;
+    }
+    
+    # 봇 차단
+    map $bad_bot $limit_bot {
+        0 "";
+        1 $binary_remote_addr;
+    }
+    limit_req_zone $limit_bot zone=bad_bot:10m rate=1r/m;
 
     upstream web_backend {
         server web:8000;
     }
 
     # 로그 설정
-    access_log /var/log/nginx/access.log;
+    access_log /var/log/nginx/access.log detailed;
     error_log /var/log/nginx/error.log warn;
 
     # 로깅 포맷
@@ -27,6 +61,27 @@ http {
                         '"$request" $status $body_bytes_sent '
                         '"$http_referer" "$http_user_agent" '
                         '"$http_x_forwarded_for"';
+
+    # 기본 서버 블록 - 유효하지 않은 호스트 헤더를 가진 모든 요청을 거부
+    server {
+        listen 80 default_server;
+        listen 443 ssl default_server;
+        server_tokens off;
+        
+        ssl_certificate /etc/letsencrypt/live/dangma.store/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/dangma.store/privkey.pem;
+        
+        # 유효하지 않은 Host 헤더를 가진 요청 로깅
+        access_log /var/log/nginx/invalid_host.log detailed;
+        
+        # Host 헤더 유효성 검사
+        if ($is_valid_host = 0) {
+            return 444;  # 응답 없이 연결 종료 (보안상 더 좋음)
+        }
+        
+        # 그 외 모든 요청 거부
+        return 403;
+    }
 
     # HTTP -> HTTPS 리디렉션
     server {
@@ -55,8 +110,42 @@ http {
         ssl_stapling_verify on;
         resolver 8.8.8.8 8.8.4.4 valid=300s;
         resolver_timeout 5s;
+        
+        # 보안 헤더 추가
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline';" always;
+        
+        # 일반적인 해킹 시도 패턴 차단 (phpMyAdmin, wp-admin 등)
+        location ~ ^/(phpMyAdmin|phpmyadmin|myadmin|mysql|database|admin|administrator|wp-admin|wp-login)/ {
+            limit_req zone=bad_bot burst=1 nodelay;
+            deny all;
+            return 403;
+        }
+        
+        # .git 및 민감한 파일 접근 차단
+        location ~ /\.(git|env|htaccess|config) {
+            deny all;
+            return 403;
+        }
+        
+        # 어드민 페이지 보호
+        location /admin/ {
+            limit_req zone=admin_limit burst=5;
+            proxy_pass http://web_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # 어드민 페이지 접근 시 봇 차단
+            if ($bad_bot = 1) {
+                return 403;
+            }
+        }
 
         location / {
+            limit_req zone=api_limit burst=20;
             proxy_pass http://web_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
### nginx.conf 수정 목록 요약

**수정 내용**
- 유효한 호스트 이름만 허용(map/if 사용, 잘못된 Host는 444 또는 403 반환)
- 보안 헤더 추가(X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, Referrer-Policy, Content-Security-Policy 등)
- 과도한 요청 제한(Rate Limiting, limit_req_zone)
- 악성/봇 User-Agent 탐지 및 제한(map, limit_req_zone)
- 상세 로그 포맷 적용(access_log detailed)
- phpMyAdmin, wp-admin 등 해킹 시도 경로 차단
- .git, .env 등 민감 파일 접근 차단
- 어드민 페이지 별도 요청 제한 및 봇 차단 적용
- 모든 location에 rate limit 적용

**특이사항**
- Host 헤더 검사로 지정된 도메인 외 요청 완전 차단(보안 강화)
- 봇 및 해킹 시도 자동 탐지 및 차단
- 모든 주요 보안 헤더 기본 적용
- 과다 트래픽 및 어드민 페이지 보호를 위한 요청 제한 강화

필요시 각 항목별로 추가 설명 가능합니다!