### PR TITLE
Develop

### DIFF
--- a/django/a_apis/schema/products.py
+++ b/django/a_apis/schema/products.py
@@ -38,6 +38,9 @@ class LocationSchema(Schema):
     description: Optional[str] = Field(
         None, description="거래 장소 설명 (예: OO역 1번 출구)"
     )
+    distance_text: Optional[str] = Field(
+        None, description="인증된 동네로부터의 거리 (예: 1.2km, 500m)"
+    )
 
     @validator("latitude")
     def validate_latitude(cls, v):


### PR DESCRIPTION
## 1. 수정목록

- `django/a_apis/schema/products.py`  
- `django/a_apis/service/products.py`  
- `django/a_apis/tests/test_products.py`  

---

## 2. 수정내용

- **LocationSchema에 distance_text 필드 추가**
  - 거래 위치에 '인증된 동네로부터의 거리'를 문자열로 표시할 수 있도록 distance_text 필드 신설.

- **ProductService에 거리 계산 기능 추가**
  - 두 지점(Point) 간 거리를 미터/킬로미터 단위로 텍스트 반환하는 `calculate_distance_text` 함수 추가.
  - 상품 상세 변환 시, 인증 동네와 거래 위치가 모두 있는 경우 두 위치의 거리를 계산해 distance_text로 반환.

- **거리 계산 및 API 응답 테스트 대폭 추가**
  - 거리 계산 함수와 상품 상세 API에서의 distance_text 정상 노출 여부 등 다양한 테스트 시나리오 추가.

---

## 3. 특이사항

- 거리는 위경도(Point) 기준 약식 계산(1도 ≈ 111km) 방식으로 변환.
- 1km 미만: "xxxm", 1km 이상: "x.xkm" 포맷으로 표시.
- 사용자 인증 동네 또는 거래 위치 정보가 없으면 distance_text는 None 처리.
- 다양한 케이스(거리 단위, 예외, API 응답 등)별 세분화된 테스트 코드 작성.