### PR TITLE
fix : models.timezome -> timezone.now() 오류 개선

### DIFF
--- a/django/a_apis/models/product.py
+++ b/django/a_apis/models/product.py
@@ -147,7 +147,7 @@ class Product(CommonModel):
             self.status = self.Status.SOLDOUT
             self.buyer = buyer
             self.final_price = final_price if final_price else self.price
-            self.completed_at = models.timezone.now()
+            self.completed_at = timezone.now()
             self.trade_complete_status = self.TradeCompleteStatus.COMPLETED
 
             logger.error(


### PR DESCRIPTION
| 수정 목록                | 수정 내용                                          | 특이 사항                 |
|--------------------------|----------------------------------------------------|---------------------------|
| completed_at 할당 방식   | models.timezone.now() → timezone.now()로 변경       | models에서 직접 timezone import 진행 |